### PR TITLE
Add save_position

### DIFF
--- a/ot_api/lh.py
+++ b/ot_api/lh.py
@@ -246,3 +246,20 @@ def drop_tip_in_place(pipette_id: str, run_id: Optional[str]=None):
   }
 
   return ot_api.runs.enqueue_command("dropTipInPlace", params, intent="setup", run_id=run_id)
+
+
+@command
+def save_position(
+  pipette_id: str,
+  position_id: Optional[str] = None,
+  fail_on_not_homed: bool = True,
+  run_id: Optional[str] = None,
+):
+  params = {
+    "pipetteId": pipette_id,
+    "failOnNotHomed": fail_on_not_homed,
+  }
+  if position_id is not None:
+    params["positionId"] = position_id
+
+  return ot_api.runs.enqueue_command("savePosition", params, intent="setup", run_id=run_id)


### PR DESCRIPTION
For PLR move_channel_xyz in opentrons_backend, this is needed to first query the current position of the pipette (any channel 0 or 1)